### PR TITLE
Don't use proxy driver for voetlab generator

### DIFF
--- a/lib/tournament_system/voetlab.rb
+++ b/lib/tournament_system/voetlab.rb
@@ -16,8 +16,6 @@ module TournamentSystem
     #                                     see {Dutch} for more details
     # @return [nil]
     def generate(driver, _options = {}) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-      driver = VoetlabDriverProxy.new(driver)
-
       teams = Algorithm::Util.padd_teams_even(driver.ranked_teams)
 
       all_matches = all_matches(driver).to_a
@@ -77,24 +75,5 @@ module TournamentSystem
         end
       end
     end
-
-    # Driver proxy disregarding matches played in previous laps of round robin
-    class VoetlabDriverProxy < DriverProxy
-      def get_team_matches(team) # rubocop:disable Metrics/AbcSize
-        matches = super
-        return [] if (matches.count % (even_team_count - 1)).zero?
-
-        match_sets = matches.group_by { |match| get_match_teams(match).to_set }
-
-        current_round = match_sets.values.map(&:count).max # FIXME: Maybe use the `guess_round` function
-        match_sets.values.map { |matches_in_set| matches_in_set[current_round - 1] }.compact
-      end
-
-      def even_team_count
-        (seeded_teams.count.to_f / 2).ceil * 2
-      end
-    end
-
-    private_constant :VoetlabDriverProxy
   end
 end

--- a/spec/tournament_system/voetlab_spec.rb
+++ b/spec/tournament_system/voetlab_spec.rb
@@ -100,12 +100,9 @@ describe TournamentSystem::Voetlab do
         }
       )
 
-      matches = described_class.generate(driver)
-
-      # Since this is a new lap of round robin, teams should again be matched solely based on score
-      expect(matches).to eq [
-        [5, 1], [3, 2], [4, nil],
-      ]
+      expect do
+        described_class.generate(driver)
+      end.to raise_exception 'No valid rounds found'
     end
 
     it 'gives expected results in scenario 1' do
@@ -117,14 +114,15 @@ describe TournamentSystem::Voetlab do
           [1, 3] => nil, [4, 2] => nil, [5, nil] => 5,
           [1, 2] => nil, [4, 5] => 4, [3, nil] => 3,
           [1, 4] => 1, [3, 5] => nil, [2, nil] => 2,
-        }
+        },
+        matches: [[1, 4], [3, 5], [2, nil]] # After completing a round robin only the last round is considered
       )
 
       matches = described_class.generate(driver)
 
       # Since this is a new lap of round robin, teams should again be matched solely based on score
       expect(matches).to eq [
-        [4, 1], [5, 3], [2, nil],
+        [4, 5], [1, 2], [3, nil],
       ]
     end
 


### PR DESCRIPTION
Don't use proxy driver for voetlab generator. Excluding matches is the responsiblity of the driver implementation.